### PR TITLE
Bump min PHP version to 8.3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -12,14 +12,10 @@ jobs:
       max-parallel: 3
       matrix:
         php:
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
-        composer: 
-          - 2  
+          - 8.4
+        composer:
+          - 2
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}
     steps:
       - name: Checkout
@@ -71,4 +67,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 composer.lock
 /.phpunit.result.cache
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "symfony/var-dumper": "^5.2 || ^6.0",
         "smarty/smarty": "^5.0",
-        "php": "^7.3 || ^8.0"
+        "php": "^8.3"
     },
     "license": "MIT",
     "authors": [
@@ -27,7 +27,7 @@
         "smarty-plugins"
     ],
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^10.0"
     },
     "scripts": {
         "test": "phpunit --testdox"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="./vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true">
     <testsuites>
         <testsuite name="Main tests">
             <directory>./tests</directory>

--- a/src/DebugExtension.php
+++ b/src/DebugExtension.php
@@ -11,32 +11,18 @@ use Smarty\Extension\Base;
  */
 class DebugExtension extends Base
 {
-    /**
-     * @var DebugPrintVarModifier
-     */
-    private $debugPrintVarModifier;
+    private readonly DebugPrintVarModifier $debugPrintVarModifier;
 
-    /**
-     * DebugExtension constructor.
-     */
     public function __construct()
     {
         $this->debugPrintVarModifier = new DebugPrintVarModifier();
     }
 
-    /**
-     * Get modifier callback
-     *
-     * @param string $modifierName Name of the modifier
-     *
-     * @return callable|null
-     */
-    public function getModifierCallback(string $modifierName)
+    public function getModifierCallback(string $modifierName): ?callable
     {
-        if ($modifierName === 'debug_print_var') {
-            return $this->debugPrintVarModifier;
-        }
-
-        return null;
+        return match($modifierName) {
+            'debug_print_var' => $this->debugPrintVarModifier,
+            default => null
+        };
     }
 }

--- a/src/DebugPrintVarModifier.php
+++ b/src/DebugPrintVarModifier.php
@@ -6,27 +6,13 @@ use ErrorException;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\Dumper\AbstractDumper;
 
-/**
- * This describes Smarty debug_print_var var modifier based on symfony var_dumper
- *
- * @package Imponeer\Smarty\Extensions\Dump
- */
 class DebugPrintVarModifier
 {
-    /**
-     * @var VarCloner
-     */
-    private $cloner;
+    private readonly VarCloner $cloner;
+    private readonly AbstractDumper $dumper;
 
-    /**
-     * @var HtmlDumper
-     */
-    private $dumper;
-
-    /**
-     * DebugPrintVarModifier constructor.
-     */
     public function __construct()
     {
         $this->cloner = new VarCloner();
@@ -36,13 +22,10 @@ class DebugPrintVarModifier
     /**
      * Executes plugin function
      *
-     * @param mixed $var Variable to print
-     *
-     * @return string
-     *
      * @throws ErrorException
      */
-    public function __invoke($var): string {
+    public function __invoke(mixed $var): string
+    {
         $memoryStream = fopen('php://memory', 'r+b');
 
         $this->dumper->dump(

--- a/tests/DebugExtensionTest.php
+++ b/tests/DebugExtensionTest.php
@@ -1,20 +1,14 @@
 <?php
 
 use Imponeer\Smarty\Extensions\Debug\DebugExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Smarty\Smarty;
 
 class DebugExtensionTest extends TestCase
 {
-    /**
-     * @var DebugExtension
-     */
-    private $extension;
-
-    /**
-     * @var Smarty
-     */
-    private $smarty;
+    private readonly DebugExtension $extension;
+    private readonly Smarty $smarty;
 
     protected function setUp(): void
     {
@@ -37,10 +31,9 @@ class DebugExtensionTest extends TestCase
 
     /**
      * Data provider for testModifierInSmartyTemplate
-     *
-     * @return array Test cases with input and expected output
      */
-    public function getInvokeData(): array {
+    public function getInvokeData(): array
+    {
         $object = new stdClass();
         $object->test = 'a';
 
@@ -49,23 +42,23 @@ class DebugExtensionTest extends TestCase
                 'input' => 'test',
                 'expected' => '&quot;test&quot;'
             ],
-            "int" => [
+            'int' => [
                 'input' => 5,
                 'expected' => '5'
             ],
-            "float" => [
+            'float' => [
                 'input' => 4.346,
-                'expected' => "4.346"
+                'expected' => '4.346'
             ],
-            "bool" => [
+            'bool' => [
                 'input' => true,
-                'expected' => "<i>true</i>"
+                'expected' => '<i>true</i>'
             ],
-            "object" => [
+            'object' => [
                 'input' => $object,
                 'expected' => '<b>stdClass Object (1)</b><br><b> -&gt;test</b> = &quot;a&quot;'
             ],
-            "array" => [
+            'array' => [
                 'input' => [
                     'key1' => 'value1',
                     'key2' => 42,
@@ -78,15 +71,8 @@ class DebugExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getInvokeData
-     *
-     * Tests that the debug_print_var modifier works correctly when used in a Smarty template
-     *
-     * @param mixed $input The input value to test
-     * @param string $expected The expected output after applying the modifier
-     */
-    public function testModifierInSmartyTemplate($input, string $expected): void
+    #[DataProvider('getInvokeData')]
+    public function testModifierInSmartyTemplate(mixed $input, string $expected): void
     {
         $this->smarty->assign('var', $input);
         $templateCode = urlencode('{$var|debug_print_var}');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated PHP and PHPUnit version requirements to support only PHP 8.3+ and PHPUnit 10+.
	- Improved PHPUnit configuration for stricter test execution and validation.
	- Enhanced .gitignore to exclude PHPUnit cache directory.
- **Refactor**
	- Modernized codebase and tests with typed readonly properties and updated method signatures.
	- Adopted new PHPUnit attribute syntax in tests and removed redundant comments.
- **Style**
	- Improved code consistency and formatting throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->