### PR TITLE
Make work with any var dumper newer than 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Smarty plugin to debug template data",
     "type": "library",
     "require": {
-        "symfony/var-dumper": "^5.2 || ^6.0",
+        "symfony/var-dumper": ">=5.2.0",
         "smarty/smarty": "^5.0",
         "php": "^8.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Smarty plugin to debug template data",
     "type": "library",
     "require": {
-        "symfony/var-dumper": ">=5.2.0",
+        "symfony/var-dumper": ">=5.2.0 <999.999.999",
         "smarty/smarty": "^5.0",
         "php": "^8.3"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the allowed version range for a dependency to support future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->